### PR TITLE
[BD-46] feat: added start:with-theme script

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "scripts": {
     "start": "piral debug",
+    "start:with-theme": "paragon install-theme && npm start && npm install",
     "build": "piral build --type emulator",
     "postinstall": "piral declaration",
     "setup": "node bin/install"


### PR DESCRIPTION
## Description
Added application start script with the ability to install the required theme (default `@openedx/brand-openedx@latest`). After interrupting a running process, the topic is automatically removed from the `node_modules` directory.

**Related to:** https://github.com/openedx/paragon/issues/2831